### PR TITLE
✨ Feat: CODEF 샌드박스 연동용 EasyCodef 초기화 컴포넌트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 firebase.json
+
+application.yaml
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ ext {
 
 dependencies {
 
-    // ===== LLM 연동 =====
-    implementation 'org.springframework.ai:spring-ai-ollama-spring-boot-starter'     // Spring AI(OpenAI 모델 스타터)
-
     // ===== 규칙 엔진(Drools/KIE) =====
     implementation 'org.drools:drools-core:10.1.0'                             // 규칙엔진 코어(실적/제외 룰)
     implementation 'org.drools:drools-compiler:10.1.0'                         // DRL 규칙 컴파일러
@@ -47,21 +44,24 @@ dependencies {
     // ===== Spring 핵심 =====
     implementation 'org.springframework.boot:spring-boot-starter-web'          // REST API(MVC/JSON)
     implementation 'org.springframework.boot:spring-boot-starter-security'     // 인증/인가
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'     // JPA/Hibernate
+//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'     // JPA/Hibernate
     implementation 'org.springframework.boot:spring-boot-starter-batch'        // 배치 잡/스케줄 처리
 
-    // ===== MyBatis =====
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5' // 명시적 SQL/매퍼(복잡쿼리/배치)
+    // ===== Codef =====
+    implementation 'io.codef.api:easycodef-java:1.0.6'
+
+//    // ===== MyBatis =====
+//    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5' // 명시적 SQL/매퍼(복잡쿼리/배치)
 
     // ===== Lombok/드라이버 =====
     compileOnly 'org.projectlombok:lombok'                                      // 보일러플레이트 제거(컴파일 전용)
     annotationProcessor 'org.projectlombok:lombok'                              // Lombok 애노테이션 프로세서
-    runtimeOnly 'com.mysql:mysql-connector-j'                                   // MySQL 드라이버(런타임)
+//    runtimeOnly 'com.mysql:mysql-connector-j'                                   // MySQL 드라이버(런타임)
 
     // ===== Test =====
     testImplementation 'org.springframework.boot:spring-boot-starter-test'      // JUnit/AssertJ/MockMvc 번들
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5' // MyBatis 테스트 유틸
-    testImplementation 'org.springframework.batch:spring-batch-test'            // Batch 테스트 유틸
+//    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5' // MyBatis 테스트 유틸
+//    testImplementation 'org.springframework.batch:spring-batch-test'            // Batch 테스트 유틸
     testImplementation 'org.springframework.security:spring-security-test'      // Security 테스트(Mock 인증)
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'                // JUnit 플랫폼 런처
 }

--- a/src/main/java/aicard/peril/third_party/account/add/AccountAdd.java
+++ b/src/main/java/aicard/peril/third_party/account/add/AccountAdd.java
@@ -1,0 +1,8 @@
+package aicard.peril.third_party.account.add;
+
+import io.codef.api.EasyCodef;
+
+public class AccountAdd {
+
+
+}

--- a/src/main/java/aicard/peril/third_party/common/TokenRequest.java
+++ b/src/main/java/aicard/peril/third_party/common/TokenRequest.java
@@ -1,0 +1,59 @@
+package aicard.peril.third_party.common;
+
+import io.codef.api.EasyCodef;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring 설정값을 이용해 CODEF 연동에 필요한 {@link EasyCodef} 객체를
+ * 초기화하고 보관하는 컴포넌트입니다.
+ * <p>
+ * CODEF 클라이언트 아이디, 시크릿, 퍼블릭 키를 주입받아
+ * 데모/정식 환경 설정과 RSA 공개키 설정을 한 번에 수행합니다.
+ */
+@Getter
+@Component
+public class TokenRequest {
+
+    /**
+     * CODEF API 호출에 사용하는 EasyCodef 객체입니다.
+     */
+    private final EasyCodef codef;
+
+    /**
+     * CODEF 클라이언트 아이디입니다.
+     */
+    private final String clientId;
+
+    /**
+     * CODEF 클라이언트 시크릿입니다.
+     */
+    private final String clientSecret;
+
+    /**
+     * CODEF RSA 퍼블릭 키입니다.
+     */
+    private final String publicKey;
+
+    /**
+     * CODEF 연동에 필요한 인증 정보를 주입받아 {@link EasyCodef} 객체를 초기화합니다.
+     *
+     * @param clientId CODEF 클라이언트 아이디
+     * @param clientSecret CODEF 클라이언트 시크릿
+     * @param publicKey CODEF RSA 퍼블릭 키
+     */
+    public TokenRequest(
+            @Value("${codef.client_id}") String clientId,
+            @Value("${codef.client_secret}") String clientSecret,
+            @Value("${codef.public_key}") String publicKey
+    ) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.publicKey = publicKey;
+
+        this.codef = new EasyCodef();
+        codef.setClientInfoForDemo(this.clientId, this.clientSecret);
+        codef.setPublicKey(this.publicKey);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,0 @@
-spring:
-  application:
-    name: peril

--- a/src/test/java/aicard/peril/third_party/common/TokenRequestTest.java
+++ b/src/test/java/aicard/peril/third_party/common/TokenRequestTest.java
@@ -1,0 +1,30 @@
+package aicard.peril.third_party.common;
+
+import io.codef.api.EasyCodef;
+import io.codef.api.EasyCodefServiceType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(
+        properties = {
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
+        }
+)
+class TokenRequestTest {
+
+    @Autowired
+    private TokenRequest tokenRequest;
+
+    @Test
+    void 샌드박스_토큰_재사용_및_신규발급_테스트() throws Exception {
+        EasyCodef codef = tokenRequest.getCodef();
+
+        String accessToken1 = codef.requestToken(EasyCodefServiceType.SANDBOX);
+        System.out.println("accessToken1 = " + accessToken1);
+
+        assertNotNull(accessToken1);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 (Description)

> 이번 PR에서 변경되거나 추가된 주요 작업을 간단히 설명해주세요.

- `Spring Bean`으로 `CODEF EasyCodef` 초기화 클래스 구현
- `@Value`를 통해 `clientId`, `clientSecret`, `publicKey` 설정값 주입
- 데모/정식 클라이언트 정보 및 `RSA` 공개키 초기화 로직 추가
- 샌드박스 환경에서 재사용할 수 있도록 공통 컴포넌트로 구성
<br>

## 🔗 관련 이슈 (Related Issues)

> 작업한 이슈 번호를 아래 형식으로 PULL REQUEST BODY에 작성해주세요.
> (PR 머지 시 해당 이슈가 자동으로 종료됩니다.)

- 이 커밋은 #2 이슈와 관련이 있습니다.

<br>

## ✅ 체크리스트 (Checklist)

> PR을 보내기 전 아래 항목들을 모두 확인해주세요.

-   [x] PR 제목은 커밋 컨벤션을 따랐습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 스스로 코드를 검토하고 불필요한 코드를 제거했습니다.
-   [x] 코드 스타일이 프로젝트 규칙과 일치합니다. (`Style`)
-   [x] 새로운 기능에 대한 테스트 코드를 추가했거나, 기존 테스트가 모두 통과했습니다. (`Test`)

<br>

## 📸 스크린샷 (Screenshots)

> 작업 내용과 관련된 스크린샷이 있다면 첨부해주세요. (UI 변경이 있는 경우)

| Before | After |
| :----: | :---: |
|        |       |

<br>

## 💬 기타 사항 (Etc)

> 리뷰어에게 전달하고 싶은 추가 정보가 있다면 자유롭게 작성해주세요.

- 토큰 발급로직을 공용 로직으로 뺐습니다 나중에 사용할때 아래와 같은느낌으로 사용해주시면 됩니다.
```java
private final TokenRequest tokenRequest;

public void createSandboxAccount() {

        EasyCodef codef = tokenRequest.getCodef();
}
```